### PR TITLE
fix connection null bug on close

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -45,11 +45,10 @@ class Client extends EventEmitter {
     // Confirmation channels: http://www.rabbitmq.com/confirms.html
     this.channel = await this.connection.createConfirmChannel();
     this.channel.on('close', () => {
-      if (!this.connection || !this.channel) return;
+      if (!this.channel) return;
       // Any unresolved operations on the channel will be abandoned.
       this.emit('close');
       this.channel = null;
-      this.connection = null;
     });
     this.channel.on('error', (err) => {
       // Server closed the channel for any reason (invalid operation).


### PR DESCRIPTION
rabbitmq doesn't properly close connections since the channel on close event sets the connection to null